### PR TITLE
feat: Add `createRouteMatcher` helper for protecting multiple pages

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -20,6 +20,11 @@ export {
   apiUrlFromPublishableKey,
 } from 'npm:@clerk/shared@^2.21.1/apiUrlFromPublishableKey';
 
+export {
+  createPathMatcher,
+  type PathMatcherParam,
+} from 'npm:@clerk/shared@^2.21.1/pathMatcher';
+
 export type {
   ActiveSessionResource,
   ActJWTClaim,

--- a/src/server/clerkClient.ts
+++ b/src/server/clerkClient.ts
@@ -1,5 +1,5 @@
 import { ClerkClient, createClerkClient } from '../deps.ts';
-import { API_URL, API_VERSION, JWT_KEY, SECRET_KEY } from './constants.ts';
+import { API_URL, API_VERSION, JWT_KEY, PUBLISHABLE_KEY, SECRET_KEY } from './constants.ts';
 
 /**
  * Clerk JavaScript Backend SDK client instance
@@ -7,6 +7,7 @@ import { API_URL, API_VERSION, JWT_KEY, SECRET_KEY } from './constants.ts';
  * @see {@link https://clerk.com/docs/references/backend/overview JavaScript Backend SDK}
  */
 export const clerkClient: ClerkClient = createClerkClient({
+  publishableKey: PUBLISHABLE_KEY,
   secretKey: SECRET_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,

--- a/src/server/mod.ts
+++ b/src/server/mod.ts
@@ -2,3 +2,4 @@ export * from 'npm:@clerk/backend@^1.24.1';
 export { clerkClient } from './clerkClient.ts';
 export { clerkMiddleware, type State } from './clerkMiddleware.ts';
 export { buildClerkProps } from './buildClerkProps.ts';
+export { createRouteMatcher } from './routeMatcher.ts';

--- a/src/server/routeMatcher.ts
+++ b/src/server/routeMatcher.ts
@@ -1,0 +1,19 @@
+import { createPathMatcher, type PathMatcherParam } from '../deps.ts';
+import { FreshContext } from 'fresh';
+
+export type RouteMatcherParam = PathMatcherParam;
+
+/**
+ * Returns a function that accepts a `Request` object and returns whether the request matches the list of
+ * predefined routes that can be passed in as the first argument.
+ *
+ * You can use glob patterns to match multiple routes or a function to match against the request object.
+ * Path patterns and regular expressions are supported, for example: `['/foo', '/bar(.*)'] or `[/^\/foo\/.*$/]`
+ * For more information, see: https://clerk.com/docs
+ */
+export const createRouteMatcher = (routes: RouteMatcherParam) => {
+  const matcher = createPathMatcher(routes);
+  return (context: FreshContext) => {
+    return matcher(context.url.pathname);
+  };
+};


### PR DESCRIPTION
Example usage:

```ts
import { define } from '../utils.ts';
import { createRouteMatcher } from '@jsrob/fresh-clerk/server';

const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])

export default define.middleware((ctx) => {
  const { userId } = ctx.state.auth;

  if (!userId && isProtectedRoute(ctx)) {
    return ctx.redirect('/sign-in');
  }

  return ctx.next();
});
```